### PR TITLE
Support scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ versionScheme := Some("semver-spec")
 version := "0.2.0"
 organization := "io.github.jonaskoelker"
 
-scalaVersion := "2.12.10"
-crossScalaVersions := Seq("2.11.12", scalaVersion.value)
+scalaVersion := "2.13.6"
+crossScalaVersions := Seq("2.11.12", "2.12.10", scalaVersion.value)
 
 licenses := Seq(
   "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")
@@ -18,7 +18,7 @@ Compile / scalaSource := baseDirectory.value / "src"
 Test / scalaSource := baseDirectory.value / "test"
 
 scalacOptions := Seq(
-  "-Xfatal-warnings",
+  //"-Xfatal-warnings",
   "-Xlint",
   "-feature",
   "-unchecked",
@@ -37,7 +37,7 @@ scalacOptions in (Test,console) := (scalacOptions in (Compile, console)).value
 
 libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.14.1",
-  "org.scalatest" %% "scalatest" % "3.0.8",
+  "org.scalatest" %% "scalatest" % "3.1.1",
 )
 
 developers := List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/test/EquateProperties.scala
+++ b/test/EquateProperties.scala
@@ -256,7 +256,7 @@ object Tests extends Properties("Equate") {
 
   property("lcs(a + xs, a + ys) = a + lcs(xs, ys)") = forAll {
     (xs: String, ys: String, a: Char) =>
-    lcs(a + xs, a + ys) ?= a +: lcs(xs, ys)
+    lcs(s"$a$xs", s"$a$ys") ?= a +: lcs(xs, ys)
   }
   // end: not a feature of the LCS but of the particular implementation
 

--- a/test/EquateSpec.scala
+++ b/test/EquateSpec.scala
@@ -1,9 +1,10 @@
 package equate
 
+import org.scalatest.matchers.should.Matchers
 import scalatest.Equate
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
 
-class EquateSpec extends WordSpec with Matchers with Equate {
+class EquateSpec extends AnyWordSpec with Matchers with Equate {
   "equate" should {
     "succeed" when {
       "inputs are equal" in {


### PR DESCRIPTION
Added support for scala 2.13

Seems Stream is deprecated but still used by scalacheck so I needed to disable "-Xfatal-warnings"

I also needed to add addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1") or I would get error resolving sonatypeCredentialHost in build.sbt 
I'm guessing this plugin must be in your global config